### PR TITLE
Ticket 51 fix - display now name updates correctly with user profile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,24 @@
 <template>
   <router-view />
 </template>
+
+<script>
+  import { useRouter } from 'vue-router';
+  import { auth } from './firebase/config';
+  import getUser from './composables/getUser';
+  export default{
+    setup(){
+      const router = useRouter();
+      const { currentUser } = getUser();
+      //global route guard that refreshes the user profile
+      //before the router redirects to any new page
+      router.beforeResolve( async () => {
+        if(currentUser.value){
+          //must be called twice
+          await auth.currentUser.reload();
+          await auth.currentUser.reload();
+        }
+      });
+    }
+  };
+</script>

--- a/src/views/PassReset/PassReset.vue
+++ b/src/views/PassReset/PassReset.vue
@@ -1,33 +1,36 @@
 <template>
-  <div class="login w-100 p-4 d-flex align-items-center justify-content-center" style="height: 70%">
-    <MDBCard :class="$style['authentication-card']" text="center">
-      <MDBCardHeader>Reset Password</MDBCardHeader>
-      <MDBCardBody>
-        <MDBCardTitle v-if="error" :class="[$style['error-message'], 'mb-4']">
-          {{ error }}
-        </MDBCardTitle>
-        <MDBCardText>
-          <form @submit.prevent="handleSubmit">
-            <MDBInput
-              id="form2Email"
-              v-model="email"
-              type="email"
-              label="Email address"
-              wrapper-class="mb-4"
-            />
-            <MDBBtn type="submit" color="primary">
-              Send reset email
-            </MDBBtn>
-          </form>
-        </MDBCardText>
-      </MDBCardBody>
-    </MDBCard>
-  </div>
+  <PageWrapper>
+    <div class="login w-100 p-4 d-flex align-items-center justify-content-center" style="height: 70%">
+      <MDBCard :class="$style['authentication-card']" text="center">
+        <MDBCardHeader>Reset Password</MDBCardHeader>
+        <MDBCardBody>
+          <MDBCardTitle v-if="error" :class="[$style['error-message'], 'mb-4']">
+            {{ error }}
+          </MDBCardTitle>
+          <MDBCardText>
+            <form @submit.prevent="handleSubmit">
+              <MDBInput
+                id="form2Email"
+                v-model="email"
+                type="email"
+                label="Email address"
+                wrapper-class="mb-4"
+              />
+              <MDBBtn type="submit" color="primary">
+                Send reset email
+              </MDBBtn>
+            </form>
+          </MDBCardText>
+        </MDBCardBody>
+      </MDBCard>
+    </div>
+  </PageWrapper>
 </template>
 
 <script>
   import { ref } from 'vue';
   import usePassReset from '../../composables/passReset';
+  import PageWrapper from '../../components/PageWrapper/PageWrapper.vue';
   import {
     MDBInput,
     MDBBtn,
@@ -46,7 +49,8 @@
       MDBCardHeader,
       MDBCardBody,
       MDBCardTitle,
-      MDBCardText
+      MDBCardText,
+      PageWrapper
     },
     setup(){
       const email = ref('');


### PR DESCRIPTION
When changing first name on user profile, the name now correctly displays when redirected to the home page, before the previous name would still be shown.
Added a global route guard which refreshes the profile details of the user whenever redirected to a new page.